### PR TITLE
Doc: add authordep in example

### DIFF
--- a/lib/Dist/Zilla/Role/BundleDeps.pm
+++ b/lib/Dist/Zilla/Role/BundleDeps.pm
@@ -71,6 +71,7 @@ our defaults are:
 These can be overridden when consuming a bundle in C<dist.ini>
 
     [@Author::MyBundle]
+    ; authordep Dist::Zilla::Role::BundleDeps
     bundledeps_phase = runtime
     bundledeps_relationship = requires
 


### PR DESCRIPTION
If the PluginBundle is used to build the distribution of the PluginBundle itself (thanks to [Bootstrap::lib]), it is important to have all its compile-time dependencies advertised as authordep in dist.ini so `dzil authordep` can report them.

So the `; authordep Dist::Zilla::Role::BundleDeps` is added in the example of usage for this use case.
